### PR TITLE
Turn off scheduled updates until fixed

### DIFF
--- a/.github/workflows/update_stats.yaml
+++ b/.github/workflows/update_stats.yaml
@@ -1,6 +1,6 @@
 on:
-  schedule:
-    - cron: '30 0 * * 1,4,5,6,0'
+  # schedule:
+    # - cron: '30 0 * * 1,4,5,6,0'
   workflow_dispatch:
 
 name: update_stats


### PR DESCRIPTION
The `update_stats` workflow is broken and should be fixed. I've turned off the cron schedule so it doesn't run in the meantime.